### PR TITLE
Allow to override build info at configure time

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -181,6 +181,19 @@ if test "x$QUO_WHICH_FC" = x; then
     QUO_WHICH_FC="none"
 fi
 
+AC_ARG_VAR(USER,[ Username used in build info (fails back to `id -u -n` output)])
+if test "x$USER" = x; then
+    USER=`id -u -n`
+fi
+AC_ARG_VAR(HOSTNAME,[ Hostname used in build info (fails back to `hostname` output)])
+if test "x$HOSTNAME" = x; then
+    HOSTNAME=`hostname`
+fi
+AC_ARG_VAR(DATE,[ Date used in build info (fails back to `date` output)])
+if test "x$DATE" = x; then
+    DATE=`date`
+fi
+
 AC_SUBST([CC])
 AC_SUBST([QUO_WHICH_CC])
 AC_SUBST([CFLAGS])
@@ -189,6 +202,9 @@ AC_SUBST([CXXFLAGS])
 AC_SUBST([CXXCPPFLAGS])
 AC_SUBST([FC])
 AC_SUBST([QUO_WHICH_FC])
+AC_SUBST([USER])
+AC_SUBST([HOSTNAME])
+AC_SUBST([DATE])
 AC_SUBST([FFLAGS])
 AC_SUBST([FCFLAGS])
 AC_SUBST([LDFLAGS])

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -17,9 +17,9 @@ quo-info.c
 
 quo_info_CPPFLAGS = \
 -I${top_srcdir}/src \
--DQUO_BUILD_USER="\"$$USER\"" \
--DQUO_BUILD_HOST="\"`hostname`\"" \
--DQUO_BUILD_DATE="\"`date`\"" \
+-DQUO_BUILD_USER="\"@USER@\"" \
+-DQUO_BUILD_HOST="\"@HOSTNAME@\"" \
+-DQUO_BUILD_DATE="\"@DATE@\"" \
 -DQUO_BUILD_PREFIX="\"@prefix@\"" \
 -DQUO_BUILD_INCLUDEDIR="\"@includedir@\"" \
 -DQUO_BUILD_LIBDIR="\"@libdir@\"" \


### PR DESCRIPTION
Sometimes you want to have a reproducible build, e.g.
https://build.opensuse.org/request/show/451980
so let's allow override user, hostname, date at
configure time. We failback to output of id, hostname, date
if variables are empty.