### PR TITLE
Replace pragma once to accommodate pgi

### DIFF
--- a/demos/callee-driven-ex-p1.h
+++ b/demos/callee-driven-ex-p1.h
@@ -7,7 +7,9 @@
  *
  */
 
-#pragma once
+#ifndef CED_EXP
+#define CED_EXP
+
 
 #include "mpi.h"
 #include "quo.h"
@@ -63,3 +65,5 @@ p1_entry_point(p1_context_t *c);
 
 int
 p1_fini(p1_context_t *p1_ctx);
+
+#endif

--- a/demos/caller-driven-ex-common.h
+++ b/demos/caller-driven-ex-common.h
@@ -7,7 +7,8 @@
  *
  */
 
-#pragma once
+#ifndef CRD_EXC
+#define CRD_EXC
 
 #include "quo.h"
 #include "mpi.h"
@@ -95,3 +96,5 @@ out:
     }
     return 0;
 }
+
+#endif

--- a/demos/caller-driven-ex-p1.h
+++ b/demos/caller-driven-ex-p1.h
@@ -7,7 +7,9 @@
  *
  */
 
-#pragma once
+#ifndef CRD_EXP
+#define CRD_EXP
+
 
 #include "caller-driven-ex-common.h"
 #include "quo.h"
@@ -22,3 +24,5 @@ p1_fini(void);
 
 int
 p1_entry_point(context_t *c);
+
+#endif

--- a/demos/mpi-openmp/eta.h
+++ b/demos/mpi-openmp/eta.h
@@ -11,7 +11,8 @@
  * Dirichlet eta function.
  */
 
-#pragma once
+#ifndef ETA_DEMO
+#define ETA_DEMO
 
 #include <inttypes.h>
 #include "mpi.h"
@@ -29,3 +30,5 @@ eta(double s,
     double **z,
     MPI_Comm comm,
     double *result);
+
+#endif

--- a/demos/mpi-openmp/zeta.h
+++ b/demos/mpi-openmp/zeta.h
@@ -11,7 +11,8 @@
  * Euler–Riemann zeta function.
  */
 
-#pragma once
+#ifndef ZETA_DEMO
+#defin ZETA_DEMO
 
 #include <inttypes.h>
 #include "mpi.h"
@@ -29,3 +30,5 @@ zeta(double s,
      double **z,
      MPI_Comm comm,
      double *result);
+
+#endif


### PR DESCRIPTION
Removing pragma once for a traditional header guard on five demo header files enables quo to be built with pgi.  This is the only reason building quo fails with pgi on LANL systems.

That said, the tests will still fail if you build with pgi + mpi loaded.  To fix this, ensure that the test isn't built with the '-std=c99' flag which also breaks pgi.  I didn't get into the configure file to fix this though because I don't know how.  

I'm in the SCC first floor pod if you have any questions.