### PR TITLE
Roll a v1.4

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9,7 +9,7 @@
 AC_PREREQ([2.71])
 
 AC_INIT([libquo],
-        [1.4],
+        [1.4.1-devel],
         [samuel@lanl.gov],
         [libquo],
         [https://lanl.github.io/libquo])

--- a/configure.ac
+++ b/configure.ac
@@ -9,7 +9,7 @@
 AC_PREREQ([2.71])
 
 AC_INIT([libquo],
-        [1.4.1-devel],
+        [1.4],
         [samuel@lanl.gov],
         [libquo],
         [https://lanl.github.io/libquo])
@@ -177,6 +177,8 @@ enable_cuda=no
 enable_nvml=no
 enable_pci=no
 enable_libudev=no
+enable_rocm=no
+enable_rsmi=no
 
 HWLOC_SET_SYMBOL_PREFIX(quo_internal_)
 


### PR DESCRIPTION
Spack testing showed that we needed to disable some hwloc features, so the new v1.4 does that.